### PR TITLE
Chore(setup): add golangci lint config and dev tools

### DIFF
--- a/.devcontainer/post-attach.sh
+++ b/.devcontainer/post-attach.sh
@@ -1,14 +1,11 @@
 #!/bin/sh
-# exit on error
 set -e
 
-# Debug mode - set to 1 to enable
-DEBUG=${DEBUG:-0}
-# Non-interactive mode - set to 1 to skip user prompts
-NONINTERACTIVE=${NONINTERACTIVE:-0}
+if ! command -v go &> /dev/null; then
+    echo "Go is not installed, please install Go first"
+    exit 1
+fi
 
-debug() {
-    if [ "$DEBUG" = "1" ]; then
-        echo "DEBUG: $1" >&2
-    fi
-}
+if ! command -v golangci-lint &> /dev/null; then
+    go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+fi

--- a/.github/workflows/no-merge-commits.yml
+++ b/.github/workflows/no-merge-commits.yml
@@ -8,13 +8,15 @@ jobs:
   check-merge-commits:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+
+      - name: Fetch base branch
+        run: |
+          git fetch origin ${{ github.base_ref }}:refs/remotes/origin/${{ github.base_ref }}
 
       - name: Check for merge commits
         run: |
-          # Find merge commits in the PR
-          MERGE_COMMITS=$(git log --merges --oneline origin/main..HEAD)
+          MERGE_COMMITS=$(git log --merges --oneline origin/${{ github.base_ref }}..HEAD)
           if [ -n "$MERGE_COMMITS" ]; then
             echo "Merge commits detected in this pull request:"
             echo "$MERGE_COMMITS"

--- a/.github/workflows/no-merge-commits.yml
+++ b/.github/workflows/no-merge-commits.yml
@@ -1,0 +1,25 @@
+name: 'Fail on Merge Commits'
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check-merge-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check for merge commits
+        run: |
+          # Find merge commits in the PR
+          MERGE_COMMITS=$(git log --merges --oneline origin/main..HEAD)
+          if [ -n "$MERGE_COMMITS" ]; then
+            echo "Merge commits detected in this pull request:"
+            echo "$MERGE_COMMITS"
+            echo "Please rebase your branch to remove merge commits."
+            exit 1
+          else
+            echo "No merge commits found."
+          fi

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,98 @@
+# golangci-lint configuration file
+# See https://golangci-lint.run/usage/configuration/ for all options
+
+run:
+  timeout: 3m
+
+linters:
+  enable:
+    - govet
+    - errcheck
+    - staticcheck
+    - gosimple
+    - unused
+    - ineffassign
+    - typecheck
+    - revive
+    - gofmt
+    - goimports
+    - misspell
+    - gocritic
+    - gocyclo
+    - unparam
+    - whitespace
+
+issues:
+  exclude-use-default: false
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters-settings:
+  gofmt:
+    simplify: true
+  goimports:
+    local-prefixes: a-la-carte
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: var-naming
+        arguments:
+          - - ID
+            - API
+            - HTTP
+            - JSON
+            - YAML
+            - URL
+            - SSH
+            - CLI
+            - TUI
+            - UI
+            - OS
+            - CPU
+            - RAM
+            - IP
+            - DNS
+            - SSL
+            - TLS
+            - REST
+            - SDK
+          - []
+          - [{}]
+  gocyclo:
+    min-complexity: 15
+  dupl:
+    threshold: 100
+  goconst:
+    min-len: 2
+    min-occurrences: 3
+  misspell:
+    locale: US
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+  gosec:
+    excludes:
+      - G101 # Look for hardcoded credentials
+      - G104 # Handle errors
+  govet:
+    check-shadowing: true
+  importas:
+    no-unaliased: true
+    no-extra-aliases: true
+    alias:
+      - pkg: a-la-carte/internal/app
+        alias: app
+  depguard:
+    listType: allow
+    packages:
+      - github.com/charmbracelet/bubbletea
+      - github.com/charmbracelet/lipgloss
+      - github.com/joho/godotenv
+      - a-la-carte/internal/app
+      - github.com/mattn/go-runewidth
+      - gopkg.in/yaml.v3

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+golangci-lint run 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing to chezmoi-a-la-carte
+
+Thank you for your interest in contributing! Please follow these guidelines to help us keep the project clean, maintainable, and easy to use for everyone.
+
+## Commit Messages
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for all commit messages.
+- Commit messages are linted and enforced by commitlint and Husky.
+
+## Linting & Code Quality
+
+- All code must pass `golangci-lint run` before commit. This is enforced by a Husky pre-commit hook.
+- You can run `golangci-lint run` manually to check for issues before committing.
+
+## Pull Requests
+
+- Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.
+- All pull requests must target the `main` branch unless otherwise specified.
+
+### Linear History Required (No Merge Commits)
+
+- **All pull requests must have a linear commit history (no merge commits).**
+- Our CI will **fail any pull request that contains a merge commit**. Please use `git rebase` to update your branch instead of merging `main`.
+- If you see a CI failure about merge commits, run:
+  ```sh
+  git fetch origin
+  git rebase origin/main
+  # Resolve any conflicts, then push with --force
+  git push --force-with-lease
+  ```
+- This policy keeps our history clean and easy to follow.
+
+## Development Quickstart
+
+1. Install Go (>=1.23)
+2. Clone the repo and run:
+   ```sh
+   go run ./cmd/chezmoi-a-la-carte
+   ```
+3. The TUI will launch. Press `q` or `Ctrl+C` to quit.
+
+## Additional Information
+
+- See the [README.md](README.md) for project overview, features, and more details.
+- For questions or help, please open an issue.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
-# chezmoi-a-la-carte
+|       |       | **a** |       | **l** | **a** |       | **c** | **a** | **r** | **t** | **e** |       |       |
+| ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- | ----- |
+| **c** | **h** | **e** | **z** | **m** | **o** | **i** |       | **p** | **l** | **u** | **g** | **i** | **n** |
 
-|       | **a** | **l** | **a** |       |
-| ----- | ----- | ----- | ----- | ----- |
-| **C** | **A** | **R** | **T** | **E** |
+---
 
-[chezmoi](https://chezmoi.io) plugin for software provisioning on new systems and container environments.
+Software provisioning and configuration for host and container environments.
 
 ---
 
 ## Project Overview
 
-**chezmoi-a-la-carte** is a Go-based plugin for chezmoi that provides an advanced, beautiful terminal user interface (TUI) for software provisioning, powered by [Bubble Tea](https://github.com/charmbracelet/bubbletea). It leverages a YAML manifest (`software.yml`) to present and manage available software packages.
+**chezmoi-a-la-carte** is a Go-based plugin for [chezmoi](https://chezmoi.io) that provides an advanced, beautiful terminal user interface (TUI) for software provisioning, powered by [Bubble Tea](https://github.com/charmbracelet/bubbletea). It leverages a YAML manifest (`software.yml`) to present and manage available software packages.
 
 - **Language:** Go
 - **TUI Framework:** Bubble Tea, Bubbles, Lip Gloss
-- **Manifest:** `software.yml`
+- **Manifest:** By default, `software.yml`. You can override this by setting the `SOFTWARE_MANIFEST_PATH` environment variable or by creating a `.env` file with `SOFTWARE_MANIFEST_PATH=yourfile.yml`.
 - **Binary Name:** `chezmoi-a-la-carte`
 - **CI/CD:** GitHub Actions, release-please
 - **Commit Style:** [Conventional Commits v1](https://www.conventionalcommits.org/en/v1.0.0/)
@@ -41,10 +41,11 @@ chezmoi-a-la-carte
    ```
 3. The TUI will launch. Press `q` or `Ctrl+C` to quit.
 4. Commit messages must follow [Conventional Commits v1](https://www.conventionalcommits.org/en/v1.0.0/), enforced by commitlint and Husky.
+5. **All code must pass `golangci-lint run` before commit.** This is enforced by a Husky pre-commit hook. VS Code is pre-configured to show lint errors on save.
 
 ## Manifest
 
-- All available software is defined in `software.yml` (YAML format).
+- All available software is defined in a YAML manifest (default: `software.yml`). You can use a different file by setting the `SOFTWARE_MANIFEST_PATH` environment variable or in a `.env` file.
 
 ## CI/CD
 
@@ -55,6 +56,7 @@ chezmoi-a-la-carte
 ## Contributing
 
 - Please use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for all commit messages.
+- **All code must pass `golangci-lint run` before commit.** The pre-commit hook will block commits with linter errors. You can also run `golangci-lint run` manually.
 - Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.
 - See the [CONTRIBUTING.md](CONTRIBUTING.md) for more details (if available).
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,7 @@ chezmoi-a-la-carte
 
 ## Contributing
 
-- Please use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for all commit messages.
-- **All code must pass `golangci-lint run` before commit.** The pre-commit hook will block commits with linter errors. You can also run `golangci-lint run` manually.
-- Pull requests are welcome! For major changes, please open an issue first to discuss what you would like to change.
-- See the [CONTRIBUTING.md](CONTRIBUTING.md) for more details (if available).
+We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on commit messages, code quality, pull request process, and our linear history (no merge commits) policy.
 
 ## Roadmap
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,34 @@
+version: '3'
+
+tasks:
+  lint:
+    desc: Run golangci-lint with correct PATH
+    cmds:
+      - |
+        export PATH="$HOME/go/bin:$PATH"
+        golangci-lint run
+
+  build:
+    desc: Build the chezmoi-a-la-carte binary
+    cmds:
+      - go build -v ./cmd/chezmoi-a-la-carte
+
+  run:
+    desc: Run the chezmoi-a-la-carte binary
+    cmds:
+      - go run ./cmd/chezmoi-a-la-carte
+
+  test:
+    desc: Run all Go tests
+    cmds:
+      - go test -v ./...
+
+  fmt:
+    desc: Format Go code
+    cmds:
+      - go fmt ./...
+
+  tidy:
+    desc: Tidy Go module dependencies
+    cmds:
+      - go mod tidy

--- a/a-la-carte.code-workspace
+++ b/a-la-carte.code-workspace
@@ -1,0 +1,112 @@
+{
+  "folders": [
+    {
+      "path": ".",
+      "name": "🇦➖🇱🇦➖🛒"
+    }
+  ],
+  "settings": {
+    "editor.fontFamily": "Operator Mono Lig",
+    "editor.fontWeight": "500",
+    "breadcrumbs.enabled": false,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.lineNumbers": "on",
+    "editor.cursorBlinking": "phase",
+    "editor.cursorSmoothCaretAnimation": "on",
+    "editor.fontLigatures": "'ss05', 'calt' 0, 'dlig' 1, 'cv10' 10, 'cv31' 3, 'cv34' 8, 'cv25' 2, 'cv50' 2, 'cv71' 2, 'cv72' 1, 'cv78' 7, 'cv90' 1",
+    "editor.fontSize": 14.5,
+    "editor.formatOnSave": true,
+    "editor.glyphMargin": true,
+    "editor.guides.bracketPairs": true,
+    "editor.bracketPairColorization.enabled": true,
+    "editor.inlineSuggest.enabled": true,
+    "editor.minimap.enabled": true,
+    "editor.renderControlCharacters": true,
+    "editor.renderWhitespace": "boundary",
+    "editor.renderLineHighlight": "all",
+    "editor.scrollBeyondLastColumn": 2,
+    "editor.showFoldingControls": "mouseover",
+    "editor.smoothScrolling": true,
+    "editor.folding": true,
+    "editor.rulers": [79],
+    "explorer.confirmDragAndDrop": false,
+    "explorer.fileNesting.enabled": false,
+    "explorer.sortOrder": "type",
+    "prettier.endOfLine": "auto",
+    "prettier.singleQuote": true,
+    "redhat.telemetry.enabled": false,
+    "files.associations": {
+      "*.d2": "d2",
+      "*.tmpl": "go-template"
+    },
+    "search.exclude": {
+      "**/.git/objects/**": true,
+      "**/.git/subtree-cache/**": true,
+      "**/dist/**": true,
+      "**/node_modules/**": true,
+      "**/tmp/**": true
+    },
+    "search.followSymlinks": false,
+    "terminal.integrated.fontLigatures": true,
+    "terminal.integrated.fontFamily": "MesloLGS NF",
+    "terminal.integrated.fontSize": 13,
+    "terminal.integrated.cursorBlinking": true,
+    "terminal.integrated.cursorStyle": "line",
+    "terminal.integrated.defaultProfile.linux": "zsh",
+    "terminal.integrated.enableMultiLinePasteWarning": "never",
+    "terminal.integrated.shellIntegration.enabled": true,
+    "terminal.integrated.scrollback": 9999999999,
+    "window.commandCenter": false,
+    "window.zoomLevel": 1.0,
+    "workbench.layoutControl.enabled": false,
+    "workbench.statusBar.visible": true,
+    "[dockerfile]": {
+      "editor.defaultFormatter": "ms-azuretools.vscode-docker"
+    },
+    "[shellscript]": {
+      "editor.defaultFormatter": "foxundermoon.shell-format"
+    },
+    "[ignore]": {
+      "editor.defaultFormatter": "foxundermoon.shell-format"
+    },
+    "go.lintTool": "golangci-lint",
+    "go.lintOnSave": "package",
+    "go.lintFlags": ["--fast"],
+    "go.useLanguageServer": true,
+    "go.toolsManagement.checkForUpdates": "local",
+    "go.toolsManagement.autoUpdate": true,
+    "go.lintToolSettings": {
+      "golangci-lint": {
+        "run": "on save",
+        "args": ["--fast"]
+      }
+    },
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": "explicit"
+    },
+    "[go]": {
+      "editor.formatOnSave": true,
+      "editor.codeActionsOnSave": {
+        "source.organizeImports": "explicit"
+      },
+      "editor.defaultFormatter": "golang.go"
+    },
+    "go.formatTool": "goimports",
+    "go.delveConfig": {
+      "dlvLoadConfig": {
+        "followPointers": true,
+        "maxVariableRecurse": 1,
+        "maxStringLen": 512,
+        "maxArrayValues": 64,
+        "maxStructFields": -1
+      }
+    },
+    "go.testFlags": ["-v"],
+    "go.coverOnSave": true,
+    "go.coverageDecorator": {
+      "type": "highlight",
+      "coveredHighlightColor": "rgba(64,128,128,0.5)",
+      "uncoveredHighlightColor": "rgba(128,64,64,0.25)"
+    }
+  }
+}

--- a/cmd/chezmoi-a-la-carte/main.go
+++ b/cmd/chezmoi-a-la-carte/main.go
@@ -8,6 +8,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/joho/godotenv"
 	"github.com/lexnux/a-la-carte/internal/app"
 	"github.com/mattn/go-runewidth"
 )
@@ -414,7 +415,18 @@ func (m model) View() string {
 }
 
 func main() {
-	manifest, err := app.LoadManifest("software.yml")
+	// Load .env if present
+	_ = godotenv.Load()
+	// Load manifest
+	manifestPath := os.Getenv("SOFTWARE_MANIFEST_PATH")
+	if manifestPath == "" {
+		manifestPath = "software.yml"
+	}
+	manifest, err := app.LoadManifest(manifestPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error loading manifest: %v\n", err)
+		os.Exit(1)
+	}
 	// Sort keys for consistent order
 	var keys []string
 	for k := range manifest {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6baUTXGLOoWe4PQhGxaX0KpnayAqC48p4=
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=

--- a/task
+++ b/task
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+./scripts/install-dev-tools.sh && $HOME/go/bin/task "$@"


### PR DESCRIPTION
This pull request introduces several enhancements to the `chezmoi-a-la-carte` project, focusing on improving development workflows, enforcing code quality, and enhancing documentation. Key changes include the addition of linting tools and configurations, updates to the development environment, and new guidelines for contributors.

### Development Workflow and Tooling Enhancements:
* Added a `.golangci.yml` file to configure `golangci-lint` with specific linters and rules for code quality enforcement.
* Updated `.devcontainer/post-attach.sh` to ensure `Go` and `golangci-lint` are installed before proceeding with development.
* Introduced a `Taskfile.yml` to streamline common development tasks such as linting, building, testing, and formatting.
* Created a Husky pre-commit hook in `.husky/pre-commit` to automatically run `golangci-lint` before commits.

### CI/CD and Version Control Improvements:
* Added a GitHub Actions workflow (`.github/workflows/no-merge-commits.yml`) to enforce a linear commit history by failing pull requests with merge commits.

### Documentation Updates:
* Expanded `CONTRIBUTING.md` with detailed guidelines on commit messages, linting requirements, and the pull request process, including the no-merge-commits policy.
* Updated `README.md` to reflect the new linting requirements, manifest configuration options, and a link to the contributing guidelines. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R44-R48) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R58)

### Codebase Enhancements:
* Modified `cmd/chezmoi-a-la-carte/main.go` to support loading environment variables from a `.env` file using `godotenv` and to allow overriding the default manifest file path via an environment variable. [[1]](diffhunk://#diff-c747842d07c86f6c8c71a6453df0723b1ea412adcded2535428420405ac3b749R11) [[2]](diffhunk://#diff-c747842d07c86f6c8c71a6453df0723b1ea412adcded2535428420405ac3b749L417-R429)
* Updated `go.mod` to include `github.com/joho/godotenv` as a dependency for environment variable management.

### Development Environment Configuration:
* Added a `a-la-carte.code-workspace` file with pre-configured settings for VS Code, including linting on save, formatting preferences, and Go-specific configurations.

These changes collectively enhance the development experience, enforce better code quality, and provide clear guidelines for contributors.