### PR TITLE
ci(workflows): use RELEASE_PLEASE_PAT for release-please authentication

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,4 +16,4 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: simple
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_PAT }}


### PR DESCRIPTION
Update .github/workflows/release-please.yml to use the RELEASE_PLEASE_PAT secret for authentication, enabling release-please to create and approve pull requests with the required permissions.

This follows GitHub and release-please best practices for least-privilege automation and resolves permission errors when using the default GITHUB_TOKEN.