### PR TITLE
ci(workflows): clear Go module cache before restoring in actions/cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
+      - name: Clean Go module and build cache
+        run: |
+          go clean -modcache
+          go clean -cache
       - name: Cache Go modules
         uses: actions/cache@v4
         with:

--- a/.github/workflows/release-artifact.yml
+++ b/.github/workflows/release-artifact.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Clean Go module and build cache
+        run: |
+          go clean -modcache
+          go clean -cache
+
       - name: Cache Go modules
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
Add a step to remove Go module and build cache directories before restoring the cache in CI and release artifact workflows. This prevents extraction errors caused by existing files and ensures reliable caching behavior.

Refs: https://github.com/actions/cache/blob/main/examples.md#go---modules-and-build-cache