### PR TITLE
ci(release-please): set initial version to 0.1.0 in config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "initial-version": "0.1.0",
   "bumpMinorPreMajor": true,
   "bumpPatchForMinorPreMajor": true,
   "defaultBranch": "main",


### PR DESCRIPTION
Configure release-please to start versioning from 0.1.0 instead of the default 1.0.0 by adding the "initial-version" property to release-please-config.json.

This ensures the first release uses the desired versioning scheme for early development.

Refs: https://github.com/googleapis/release-please#how-do-i-configure-the-initial-version