### PR TITLE
chore(release): remove release-type from GitHub Actions workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,5 +15,4 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v4
         with:
-          release-type: simple
           token: ${{ secrets.RELEASE_PLEASE_PAT }}


### PR DESCRIPTION
Let the release-please-action use the configuration from release-please-config.json, ensuring correct versioning and release strategy for the project.