### PR TITLE
chore(release)/allow workflow dispatch release

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_PAT }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/release-please.yml` file to enhance the GitHub Actions workflow for release automation. The changes include enabling manual workflow dispatch and adding a step to check out the repository before running the release action.

Workflow enhancements:

* Added `workflow_dispatch` to the `on:` section, allowing the workflow to be triggered manually.
* Included a `checkout` step using `actions/checkout@v4` in the `release-please` job to ensure the repository is cloned before executing the release action.