### PR TITLE
chore(release): bump initial version and add packages config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,5 +4,8 @@
   "bumpMinorPreMajor": true,
   "bumpPatchForMinorPreMajor": true,
   "defaultBranch": "main",
-  "release-type": "go"
+  "release-type": "go",
+  "packages": {
+    ".": {}
+  }
 }


### PR DESCRIPTION
- Set initial-version to 0.1.1 to force a new initial release
- Add packages field to support monorepo or advanced configuration