### PR TITLE
ci(github-actions): add and configure lint-actions workflow

### DIFF
--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,30 @@
+name: Github Actions
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+
+defaults:
+  run:
+    working-directory: ./.github
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github
+
+      - uses: reviewdog/action-actionlint@a5524e1c19e62881d79c1f1b9b6f09f16356e281 # v1.65.2
+        with:
+          filter_mode: nofilter
+          fail_level: error
+          reporter: github-pr-check


### PR DESCRIPTION
Adds a GitHub Actions workflow to lint workflow files using actionlint and reviewdog. The workflow runs on pull requests affecting .github/, checks out only the .github directory, and reports lint results via GitHub PR checks.

- Uses actions/checkout@v4.2.2 with sparse checkout for .github
- Runs reviewdog/action-actionlint@v1.65.2 for workflow linting
- Sets working directory to .github for all steps
- Restricts permissions to read-only for contents

This improves CI quality by ensuring all workflow files are linted on PRs.