### PR TITLE
ci(github-actions):  ignore 'autorelease: pending' label

### DIFF
--- a/.github/workflows/check-lint-pr.yml
+++ b/.github/workflows/check-lint-pr.yml
@@ -23,3 +23,4 @@ jobs:
         with:
           ignoreLabels: |
             release
+            autorelease: pending


### PR DESCRIPTION
 ignore 'autorelease: pending' label