### PR TITLE
chore(goreleaser): fiix deprecated archive formats in configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,10 +19,10 @@ builds:
 archives:
   - id: default
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
-    format: tar.gz
+    formats: [tar.gz]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     files:
       - README.md
       - LICENSE


### PR DESCRIPTION
- Changed 'format' to 'formats' for better compatibility.
- Updated Windows archive format to use 'formats' array.