### PR TITLE
feat(config): introduce app config system

### DIFF
--- a/.github/commit-message.md
+++ b/.github/commit-message.md
@@ -1,0 +1,121 @@
+<!--
+COPILOT COMMIT MESSAGE GENERATOR PROMPT
+This file serves as a prompt template for GitHub Copilot to generate standardized git commit messages
+that are compatible with both Conventional Commits v1.0.0 and release-please integration.
+-->
+
+# Git Commit Message Generator
+
+## SYSTEM INSTRUCTIONS
+
+You are a specialized git commit message generator. Based on the git diff provided, generate ONLY a properly formatted commit message following Conventional Commits 1.0.0 specification with the refinements below. The full specification can be found at `https://www.conventionalcommits.org/en/v1.0.0/`. Your response must contain NOTHING but the commit message itself.
+
+## COMMIT FORMAT SPECIFICATION
+
+### Header (Required)
+
+- Format: `<type>([scope])[!]: <description>`
+- Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+- Scope: Optional section name in parentheses (e.g., tui, api, release, components, manifest)
+- Breaking Change: Add "!" before colon for breaking changes
+- Description: Short imperative summary (no capitalization, no period)
+- ALL elements combined, the header line MUST be no more than 50 chars in length
+
+### Body (Optional)
+
+- Separated from header by blank line
+- Use English paragraphs starting with a capital letter and ending in a period
+- Maximum 72 characters per line
+- Focus on what and why, not how
+- Be objective and use imperative mood
+- For breaking changes, start with "BREAKING CHANGE:" followed by a description
+
+### Footer (Optional)
+
+- Format: `<token>: <value>` (72 chars max per line)
+- Common tokens: BREAKING CHANGE, Fixes, Closes, Resolves, References
+- For breaking changes, use both "!" in header AND "BREAKING CHANGE:" in footer
+- Always include issue references when applicable
+
+## TYPE DEFINITIONS
+
+- feat: New feature (triggers minor version bump)
+- fix: Bug fix (triggers patch version bump)
+- docs: Documentation changes only
+- style: Code style changes (formatting, semicolons, etc.)
+- refactor: Code changes that neither fix bugs nor add features
+- perf: Performance improvements
+- test: Test additions or corrections
+- build: Build system or external dependency changes
+- ci: CI configuration changes
+- chore: Routine maintenance tasks
+- revert: Reverting previous commits
+
+## OUTPUT RULES
+
+1. Include ONLY the commit message and its defined sections
+2. Write in English only
+3. Use imperative present tense ("add" not "added")
+4. No capitalization in description
+5. No period at end of description
+6. Maximum 50 characters for header line
+7. Maximum 72 characters for body/footer lines
+8. Include relevant scope when possible
+9. For breaking changes:
+   - Add "!" before colon in header
+   - Include "BREAKING CHANGE:" in footer
+   - Explain impact in body
+10. Always reference issues when applicable
+11. Keep descriptions concise and clear
+12. Avoid unnecessary adjectives
+
+## COMMIT ANALYSIS PROCESS
+
+1. Examine the provided git diff carefully
+2. Identify the primary purpose of the changes
+3. Determine the appropriate type and scope
+4. Create a concise, descriptive summary
+5. Add explanatory body paragraph(s) if needed
+6. Include relevant footers (issue references, breaking changes)
+7. Verify the message follows release-please requirements
+
+## EXAMPLES
+
+Example 1 (Feature with Issue Reference):
+
+```
+feat(tui): add software search functionality
+
+Implement a new search feature in the TUI that allows users to quickly find
+software packages by name or description. The search is case-insensitive and
+updates results in real-time as the user types.
+
+Closes #423
+```
+
+Example 2 (Bug Fix with Breaking Change):
+
+```
+fix(api)!: handle null response from legacy service
+
+Implement robust error handling for legacy service responses by adding null
+checks before JSON parsing. When the service is unavailable, return a clear
+error message to help users understand and resolve the issue.
+
+BREAKING CHANGE: API now returns error object instead of null for unavailable
+services. Clients must handle the new error response format.
+
+Fixes #512
+```
+
+Example 3 (Release Management):
+
+```
+chore(release): bump version to 0.2.0
+
+Update version numbers and changelog in preparation for the 0.2.0 release.
+This release includes several new features and bug fixes as documented in
+the changelog.
+
+Closes #789
+```

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,7 +80,6 @@ linters-settings:
       - G101 # Look for hardcoded credentials
       - G104 # Handle errors
   govet:
-    check-shadowing: true
   importas:
     no-unaliased: true
     no-extra-aliases: true

--- a/a-la-carte.code-workspace
+++ b/a-la-carte.code-workspace
@@ -32,13 +32,18 @@
     "explorer.confirmDragAndDrop": false,
     "explorer.fileNesting.enabled": false,
     "explorer.sortOrder": "type",
-    "prettier.endOfLine": "auto",
-    "prettier.singleQuote": true,
-    "redhat.telemetry.enabled": false,
+    "github.copilot.chat.commitMessageGeneration.instructions": [
+      {
+        "file": ".github/commit-message-improved.md"
+      }
+    ],
     "files.associations": {
       "*.d2": "d2",
       "*.tmpl": "go-template"
     },
+    "prettier.endOfLine": "auto",
+    "prettier.singleQuote": true,
+    "redhat.telemetry.enabled": false,
     "search.exclude": {
       "**/.git/objects/**": true,
       "**/.git/subtree-cache/**": true,

--- a/a-la-carte.code-workspace
+++ b/a-la-carte.code-workspace
@@ -2,7 +2,7 @@
   "folders": [
     {
       "path": ".",
-      "name": "🇦➖🇱🇦➖🛒"
+      "name": "à-la-🛒"
     }
   ],
   "settings": {
@@ -75,12 +75,6 @@
     "go.useLanguageServer": true,
     "go.toolsManagement.checkForUpdates": "local",
     "go.toolsManagement.autoUpdate": true,
-    "go.lintToolSettings": {
-      "golangci-lint": {
-        "run": "on save",
-        "args": ["--fast"]
-      }
-    },
     "editor.codeActionsOnSave": {
       "source.organizeImports": "explicit"
     },

--- a/docs/configuration-system.md
+++ b/docs/configuration-system.md
@@ -1,0 +1,106 @@
+# Configuration System
+
+This document provides an overview of the configuration system for the a-la-carte application, including the configuration loading process, components, and potential improvements.
+
+## Components
+
+The configuration system consists of the following main components:
+
+1. **Config Package** (`internal/config/`):
+
+   - Configuration structure definition
+   - File loading and resolution
+   - Validation logic
+   - Output format support
+
+2. **Flags Package** (`internal/flags/`):
+
+   - Command-line flag parsing
+   - Option validation
+   - Usage information
+
+3. **Main Package Integration** (`cmd/chezmoi-a-la-carte/main.go`):
+   - Configuration loading orchestration
+   - Error handling and reporting
+
+## Configuration Loading Process
+
+The system loads configuration in this order of precedence (highest to lowest):
+
+1. **Command-line arguments** (direct overrides like `--debug`)
+2. **Environment variable** (`A_LA_CARTE_CONFIG`)
+3. **Command-line specified config file** (`--config`)
+4. **XDG config location** (`$HOME/.config/a-la-carte/a-la-carte.yml`)
+5. **Built-in defaults**
+
+## Implementation Details
+
+The `loadConfig()` function in `main.go` orchestrates this process:
+
+1. It first checks for a config file path from command-line options
+2. If not present, it uses `FindConfigFile()` to check environment variables and standard locations
+3. It loads the configuration from the file, or uses defaults if no file is found
+4. It applies any command-line overrides (like debug mode)
+5. It validates the final configuration
+
+## Current Status
+
+All the essential components of a robust configuration system are implemented, including:
+
+- Configuration structure definition
+- File loading and precedence handling
+- Command-line flag integration
+- Validation logic
+- Output format support
+- Documentation
+
+## Configuration File Format
+
+The configuration file uses YAML format. Here's an example:
+
+```yaml
+# UI Configuration
+ui:
+  # Theme can be light, dark, or system
+  theme: dark
+
+  # UI dimensions
+  detailHeight: 10
+  listHeight: 10
+
+  # Whether to show emojis in the UI
+  emojisEnabled: true
+
+# Software configuration
+software:
+  # Path to the software manifest
+  manifestPath: software.yml
+
+  # Software keys to preload (automatically selected when app starts)
+  preloadKeys:
+    - git
+    - vim
+    - go
+
+# System settings
+system:
+  # Enable debug mode
+  debugMode: false
+```
+
+## Potential Improvements
+
+Based on the current implementation, these improvements could be made:
+
+1. **User settings system** for persistent preferences
+2. **Additional output formats** (e.g., YAML)
+3. **Environment variable overrides** for individual settings (not just the config file path)
+4. **UI adjustments** based on configuration settings
+
+## Module Documentation
+
+For more detailed information about each component:
+
+- [Config Package Documentation](internal/config/README.md)
+- [Flags Package Documentation](internal/flags/README.md)
+- [Main Package Documentation](cmd/chezmoi-a-la-carte/README.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,146 @@
+# Configuration System for Chezmoi à la Carte
+
+This document explains the configuration system for the Chezmoi à la Carte application.
+
+## Configuration Precedence
+
+Configuration settings are loaded from the following sources in order of precedence (highest to lowest):
+
+1. **Command line arguments**: Direct arguments override any other settings
+2. **Environment variables**: `A_LA_CARTE_CONFIG` pointing to a config file
+3. **Command line config flag**: `--config /path/to/config.yml`
+4. **XDG config file**: `$HOME/.config/a-la-carte/a-la-carte.yml`
+5. **Built-in defaults**: Fallback settings when no configuration is provided
+
+## Command Line Arguments
+
+The application supports the following command line arguments:
+
+| Argument          | Short | Description                                        |
+| ----------------- | ----- | -------------------------------------------------- |
+| `--config FILE`   | `-c`  | Path to configuration file                         |
+| `--manifest FILE` | `-m`  | Path to software manifest file                     |
+| `--debug`         | `-d`  | Enable debug mode                                  |
+| `--version`       | `-v`  | Show version and exit                              |
+| `--help`          | `-h`  | Show help message                                  |
+| `--output FORMAT` | `-o`  | Output format (text, json) for non-interactive use |
+| `--quiet`         | `-q`  | Suppress non-essential output                      |
+| `--no-emojis`     | `-E`  | Disable emojis in the UI                           |
+
+### Examples
+
+```bash
+# Run with a custom config file
+chezmoi-a-la-carte --config ~/.config/my-custom-config.yml
+
+# Run with a specific manifest file
+chezmoi-a-la-carte --manifest ~/projects/software-list.yml
+
+# Enable debug mode
+chezmoi-a-la-carte --debug
+
+# Show version and exit
+chezmoi-a-la-carte --version
+
+# Show help
+chezmoi-a-la-carte --help
+
+# Use JSON output format and suppress non-essential output
+chezmoi-a-la-carte --output json --quiet
+```
+
+## Environment Variables
+
+The application recognizes the following environment variables:
+
+| Variable            | Description                                       |
+| ------------------- | ------------------------------------------------- |
+| `A_LA_CARTE_CONFIG` | Path to a configuration file (highest precedence) |
+
+## Configuration File Format
+
+The configuration file uses YAML format. Here's an example:
+
+```yaml
+# UI Configuration
+ui:
+  # Theme can be light, dark, or system
+  theme: dark
+
+  # UI dimensions
+  detailHeight: 10
+  listHeight: 10
+
+  # Whether to show emojis in the UI
+  emojisEnabled: true
+
+# Software configuration
+software:
+  # Path to the software manifest
+  manifestPath: software.yml
+
+  # Software keys to preload (automatically selected when app starts)
+  preloadKeys:
+    - git
+    - vim
+    - go
+
+# System settings
+system:
+  # Enable debug mode
+  debugMode: false
+```
+
+# List of software keys to preload
+
+preloadKeys: - git - vim - go
+
+# System settings
+
+system:
+
+# Enable debug mode (can also be enabled with --debug flag)
+
+debugMode: false
+
+```
+
+## Command Line Flags
+
+The following command line flags are available:
+
+```
+
+--config, -c Path to configuration file
+--debug, -d Enable debug mode
+--version, -v Show version and exit
+--help, -h Show help message
+--no-emojis, -E Disable emojis in the UI
+
+````
+
+## Environment Variables
+
+- `A_LA_CARTE_CONFIG`: Path to a configuration file
+- `XDG_CONFIG_HOME`: Base directory for configuration files (defaults to `$HOME/.config`)
+
+## Default Configuration
+
+If no configuration file is found, the application will use the following default settings:
+
+- UI Theme: dark
+- Detail Height: 10
+- List Height: 10
+- Emojis Enabled: true
+- Software Manifest Path: software.yml
+- Debug Mode: false
+
+## Creating a Configuration File
+
+You can create a custom configuration file by copying the example:
+
+```bash
+cp a-la-carte.example.yml ~/.config/a-la-carte/a-la-carte.yml
+````
+
+Then edit the file to suit your preferences.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.23.0
 toolchain go1.23.9
 
 require (
+	github.com/76creates/stickers v1.4.1
+	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.5
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/joho/godotenv v1.5.1
@@ -13,6 +15,7 @@ require (
 )
 
 require (
+	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
+github.com/76creates/stickers v1.4.1 h1:cd9qM1+FuM7TFStTRxEMEWNpyCY5CIJ05xvKdA+fwk4=
+github.com/76creates/stickers v1.4.1/go.mod h1:S0ii0IRGMJx5n5zGpesai8oX0DWY3X5PDI3OUErgF38=
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
+github.com/charmbracelet/bubbles v0.21.0 h1:9TdC97SdRVg/1aaXNVWfFH3nnLAwOXr8Fn6u6mfQdFs=
+github.com/charmbracelet/bubbles v0.21.0/go.mod h1:HF+v6QUR4HkEpz62dx7ym2xc71/KBHg+zKwJtMw+qtg=
 github.com/charmbracelet/bubbletea v1.3.5 h1:JAMNLTbqMOhSwoELIr0qyP4VidFq72/6E9j7HHmRKQc=
 github.com/charmbracelet/bubbletea v1.3.5/go.mod h1:TkCnmH+aBd4LrXhXcqrKiYwRs7qyQx5rBgH5fVY3v54=
 github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc h1:4pZI35227imm7yK2bGPcfpFEmuY1gc2YSTShr4iJBfs=

--- a/internal/app/manifest.go
+++ b/internal/app/manifest.go
@@ -54,6 +54,10 @@ func (s *StringOrSlice) UnmarshalYAML(value *yaml.Node) error {
 // # Fields
 //   - Bin, Desc, Docs, Github, Home, Name, Short, Groups: metadata fields
 //   - Brew, Apt, Pacman, etc.: installation methods for various package managers
+//   - Deps: list of dependency keys
+//   - App: GUI app identifier (if present)
+//   - Script: Script(s) to run as part of provisioning
+//   - Lazy: If true, only install with --lazy flag
 //
 // # Example
 //
@@ -93,6 +97,10 @@ type SoftwareEntry struct {
 	Zypper        StringOrSlice `yaml:"zypper"`
 	Cargo         StringOrSlice `yaml:"cargo"`
 	Pipx          StringOrSlice `yaml:"pipx"`
+	Deps          StringOrSlice `yaml:"deps"`
+	App           string        `yaml:"_app"`   // GUI app identifier (if present)
+	Script        StringOrSlice `yaml:"script"` // Script(s) to run as part of provisioning
+	Lazy          bool          `yaml:"lazy"`   // If true, only install with --lazy flag
 	// Add more fields as needed
 }
 

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -1,0 +1,80 @@
+# Configuration Package
+
+This package provides configuration management for the a-la-carte application.
+
+## Overview
+
+The `config` package manages the application's configuration, including loading from various sources, validation, and providing utilities for manipulating configuration data.
+
+## Configuration Precedence
+
+Configuration settings are loaded from the following sources in order of precedence (highest to lowest):
+
+1. **Command-line arguments** (direct overrides like `--debug`)
+2. **Environment variable** (`A_LA_CARTE_CONFIG`) pointing to a config file
+3. **Command-line specified config file** (`--config`)
+4. **XDG config location** (`$HOME/.config/a-la-carte/a-la-carte.yml`)
+5. **Built-in defaults**
+
+## Configuration Structure
+
+The main configuration struct includes:
+
+- **UI settings**: Theme, layout dimensions, emoji support
+- **Software settings**: Manifest path, preload keys
+- **System settings**: Debug mode, etc.
+
+## Main Functions
+
+- `DefaultConfig()`: Returns a configuration with default values
+- `Load(configPath string)`: Loads configuration from a specific file path
+- `FindConfigFile()`: Searches for a config file in standard locations
+- `Validate()`: Validates the configuration values
+- `Save(path string)`: Writes configuration to a file
+- `SaveToDefaultLocation()`: Saves to the default XDG config location
+
+## Output Format Handling
+
+The package includes support for different output formats:
+
+- Text output (default human-readable format)
+- JSON output (for scripting/programmatic use)
+
+## Validation
+
+Configuration validation includes:
+
+- Validating UI theme values
+- Checking UI dimensions are positive
+- Verifying manifest path exists and is readable
+- Resolving relative paths to absolute paths
+
+## Example Usage
+
+```go
+// Load configuration with proper precedence
+cfg, err := config.Load(configPath)
+if err != nil {
+    // Handle error
+}
+
+// Override with command-line flags if needed
+if commandLineDebug {
+    cfg.System.DebugMode = true
+}
+
+// Validate configuration
+if err := cfg.Validate(); err != nil {
+    // Handle validation error
+}
+
+// Use configuration
+manifestPath := cfg.ResolveManifestPath()
+```
+
+## Potential Improvements
+
+- User settings system for persistent preferences
+- Additional output formats (e.g., YAML)
+- Environment variable overrides for individual settings (not just the config file path)
+- UI adjustments based on configuration settings

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,7 +125,12 @@ func Load(configPath string) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error opening config file: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			// If we already have an error, don't overwrite it
+			fmt.Fprintf(os.Stderr, "error closing config file: %v\n", closeErr)
+		}
+	}()
 
 	c := DefaultConfig()
 	decoder := yaml.NewDecoder(f)
@@ -171,7 +176,7 @@ func FindConfigFile() string {
 func (c *Config) Save(path string) error {
 	// Ensure directory exists
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("error creating config directory: %w", err)
 	}
 
@@ -180,7 +185,12 @@ func (c *Config) Save(path string) error {
 	if err != nil {
 		return fmt.Errorf("error creating config file: %w", err)
 	}
-	defer f.Close()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			// If we already have an error, don't overwrite it
+			fmt.Fprintf(os.Stderr, "error closing config file: %v\n", closeErr)
+		}
+	}()
 
 	encoder := yaml.NewEncoder(f)
 	encoder.SetIndent(2)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,262 @@
+// Package config provides configuration management for the a-la-carte application.
+//
+// The configuration is loaded with the following precedence (highest to lowest):
+// 1. Environment variable (A_LA_CARTE_CONFIG)
+// 2. Command line flags (--config)
+// 3. XDG config file ($HOME/.config/a-la-carte/a-la-carte.yml)
+// 4. Built-in defaults
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// EnvConfigPath is the environment variable name for the config path
+	EnvConfigPath = "A_LA_CARTE_CONFIG"
+
+	// DefaultConfigFilename is the default config filename
+	DefaultConfigFilename = "a-la-carte.yml"
+
+	// DefaultConfigDirname is the default config directory name under XDG_CONFIG_HOME
+	DefaultConfigDirname = "a-la-carte"
+)
+
+var (
+	// ErrNoConfig is returned when no config file is found
+	ErrNoConfig = errors.New("no configuration file found")
+)
+
+// Config represents the application configuration
+type Config struct {
+	// UI configuration settings
+	UI struct {
+		// Theme controls the color scheme (light, dark, system)
+		Theme string `yaml:"theme,omitempty"`
+		// DetailHeight is the height of the detail pane
+		DetailHeight int `yaml:"detailHeight,omitempty"`
+		// ListHeight is the height of the list pane
+		ListHeight int `yaml:"listHeight,omitempty"`
+		// EmojisEnabled controls whether emojis are displayed in the UI
+		EmojisEnabled bool `yaml:"emojisEnabled,omitempty"`
+	} `yaml:"ui,omitempty"`
+
+	// Software configuration
+	Software struct {
+		// ManifestPath is the path to the software manifest
+		ManifestPath string `yaml:"manifestPath,omitempty"`
+		// PreloadKeys are software keys to preload
+		PreloadKeys []string `yaml:"preloadKeys,omitempty"`
+	} `yaml:"software,omitempty"`
+
+	// System settings
+	System struct {
+		// DebugMode enables debug logging
+		DebugMode bool `yaml:"debugMode,omitempty"`
+	} `yaml:"system,omitempty"`
+
+	// ConfigPath stores the path where the config was loaded from
+	ConfigPath string `yaml:"-"`
+}
+
+// DefaultConfig returns the default configuration
+func DefaultConfig() *Config {
+	c := &Config{}
+
+	// UI defaults
+	c.UI.Theme = "dark"
+	c.UI.DetailHeight = 10
+	c.UI.ListHeight = 10
+	c.UI.EmojisEnabled = true
+
+	// Software defaults
+	c.Software.ManifestPath = "software.yml"
+	c.Software.PreloadKeys = []string{}
+
+	// System defaults
+	c.System.DebugMode = false
+
+	return c
+}
+
+// Validate checks if the configuration is valid
+// Returns nil if valid, otherwise returns an error
+func (c *Config) Validate() error {
+	// Validate UI theme
+	validThemes := map[string]bool{
+		"dark":   true,
+		"light":  true,
+		"system": true,
+	}
+	if !validThemes[c.UI.Theme] {
+		return fmt.Errorf("invalid UI theme: %s (must be 'dark', 'light', or 'system')", c.UI.Theme)
+	}
+
+	// Validate UI dimensions
+	if c.UI.DetailHeight < 1 {
+		return fmt.Errorf("invalid detail height: %d (must be > 0)", c.UI.DetailHeight)
+	}
+
+	if c.UI.ListHeight < 1 {
+		return fmt.Errorf("invalid list height: %d (must be > 0)", c.UI.ListHeight)
+	}
+
+	// Validate software manifest path
+	if c.Software.ManifestPath == "" {
+		return errors.New("software manifest path cannot be empty")
+	}
+
+	return nil
+}
+
+// Load loads configuration from a specific file path
+func Load(configPath string) (*Config, error) {
+	if configPath == "" {
+		return nil, ErrNoConfig
+	}
+
+	f, err := os.Open(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening config file: %w", err)
+	}
+	defer f.Close()
+
+	c := DefaultConfig()
+	decoder := yaml.NewDecoder(f)
+	if err := decoder.Decode(c); err != nil {
+		return nil, fmt.Errorf("error parsing config file: %w", err)
+	}
+
+	c.ConfigPath = configPath
+	return c, nil
+}
+
+// FindConfigFile searches for a config file in the standard locations:
+// 1. Environment variable A_LA_CARTE_CONFIG
+// 2. $HOME/.config/a-la-carte/a-la-carte.yml
+func FindConfigFile() string {
+	// Check environment variable first
+	if envPath := os.Getenv(EnvConfigPath); envPath != "" {
+		if _, err := os.Stat(envPath); err == nil {
+			return envPath
+		}
+	}
+
+	// Check XDG config directory
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome == "" {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			xdgConfigHome = filepath.Join(home, ".config")
+		}
+	}
+
+	if xdgConfigHome != "" {
+		configPath := filepath.Join(xdgConfigHome, DefaultConfigDirname, DefaultConfigFilename)
+		if _, err := os.Stat(configPath); err == nil {
+			return configPath
+		}
+	}
+
+	return ""
+}
+
+// Save writes the configuration to the specified file
+func (c *Config) Save(path string) error {
+	// Ensure directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("error creating config directory: %w", err)
+	}
+
+	// Create or truncate the file
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("error creating config file: %w", err)
+	}
+	defer f.Close()
+
+	encoder := yaml.NewEncoder(f)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(c); err != nil {
+		return fmt.Errorf("error encoding config: %w", err)
+	}
+
+	return nil
+}
+
+// SaveToDefaultLocation saves the configuration to the default XDG config location
+func (c *Config) SaveToDefaultLocation() error {
+	// Get XDG config home
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("error getting user home directory: %w", err)
+		}
+		xdgConfigHome = filepath.Join(home, ".config")
+	}
+
+	// Create the path
+	path := filepath.Join(xdgConfigHome, DefaultConfigDirname, DefaultConfigFilename)
+	return c.Save(path)
+}
+
+// CreateDefault creates a default configuration file in the default XDG location
+// only if one doesn't already exist
+func CreateDefault() (string, error) {
+	// Check if a config file already exists
+	if path := FindConfigFile(); path != "" {
+		return path, nil // Config file already exists
+	}
+
+	// Create a default config
+	c := DefaultConfig()
+
+	// Save it
+	if err := c.SaveToDefaultLocation(); err != nil {
+		return "", err
+	}
+
+	// Return the path
+	xdgConfigHome := os.Getenv("XDG_CONFIG_HOME")
+	if xdgConfigHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("error getting user home directory: %w", err)
+		}
+		xdgConfigHome = filepath.Join(home, ".config")
+	}
+
+	path := filepath.Join(xdgConfigHome, DefaultConfigDirname, DefaultConfigFilename)
+	return path, nil
+}
+
+// String returns a string representation of the configuration for debugging
+func (c *Config) String() string {
+	var b strings.Builder
+
+	b.WriteString("Configuration:\n")
+	b.WriteString(fmt.Sprintf("  Config Path: %s\n", c.ConfigPath))
+	b.WriteString(fmt.Sprintf("  UI Theme: %s\n", c.UI.Theme))
+	b.WriteString(fmt.Sprintf("  UI Detail Height: %d\n", c.UI.DetailHeight))
+	b.WriteString(fmt.Sprintf("  UI List Height: %d\n", c.UI.ListHeight))
+	b.WriteString(fmt.Sprintf("  UI Emojis Enabled: %v\n", c.UI.EmojisEnabled))
+	b.WriteString(fmt.Sprintf("  Software Manifest Path: %s\n", c.Software.ManifestPath))
+	b.WriteString(fmt.Sprintf("  System Debug Mode: %v\n", c.System.DebugMode))
+
+	if len(c.Software.PreloadKeys) > 0 {
+		b.WriteString("  Preloaded Keys:\n")
+		for _, key := range c.Software.PreloadKeys {
+			b.WriteString(fmt.Sprintf("    - %s\n", key))
+		}
+	}
+
+	return b.String()
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,216 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupTestConfig creates a temporary config file for testing
+func setupTestConfig(t *testing.T) (string, func()) {
+	t.Helper()
+
+	// Create a temporary directory
+	tempDir, err := os.MkdirTemp("", "a-la-carte-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	// Create a temporary config file
+	configPath := filepath.Join(tempDir, "a-la-carte.yml")
+	configContent := `
+ui:
+  theme: dark
+  detailHeight: 15
+  listHeight: 20
+
+software:
+  manifestPath: test-manifest.yml
+  preloadKeys:
+    - git
+    - vim
+
+system:
+  debugMode: true
+`
+
+	err = os.WriteFile(configPath, []byte(configContent), 0644)
+	if err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	// Create a cleanup function
+	cleanup := func() {
+		os.RemoveAll(tempDir)
+	}
+
+	return configPath, cleanup
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+
+	// Verify default values
+	if cfg.UI.Theme != "dark" {
+		t.Errorf("expected default theme 'dark', got %s", cfg.UI.Theme)
+	}
+
+	if cfg.UI.DetailHeight != 10 {
+		t.Errorf("expected default detail height 10, got %d", cfg.UI.DetailHeight)
+	}
+
+	if cfg.UI.ListHeight != 10 {
+		t.Errorf("expected default list height 10, got %d", cfg.UI.ListHeight)
+	}
+
+	if cfg.Software.ManifestPath != "software.yml" {
+		t.Errorf("expected default manifest path 'software.yml', got %s", cfg.Software.ManifestPath)
+	}
+
+	if cfg.System.DebugMode != false {
+		t.Errorf("expected default debug mode 'false', got %v", cfg.System.DebugMode)
+	}
+
+	if len(cfg.Software.PreloadKeys) != 0 {
+		t.Errorf("expected empty preload keys, got %v", cfg.Software.PreloadKeys)
+	}
+}
+
+func TestLoad(t *testing.T) {
+	configPath, cleanup := setupTestConfig(t)
+	defer cleanup()
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("failed to load config: %v", err)
+	}
+
+	// Verify loaded values
+	if cfg.UI.Theme != "dark" {
+		t.Errorf("expected theme 'dark', got %s", cfg.UI.Theme)
+	}
+
+	if cfg.UI.DetailHeight != 15 {
+		t.Errorf("expected detail height 15, got %d", cfg.UI.DetailHeight)
+	}
+
+	if cfg.UI.ListHeight != 20 {
+		t.Errorf("expected list height 20, got %d", cfg.UI.ListHeight)
+	}
+
+	if cfg.Software.ManifestPath != "test-manifest.yml" {
+		t.Errorf("expected manifest path 'test-manifest.yml', got %s", cfg.Software.ManifestPath)
+	}
+
+	if cfg.System.DebugMode != true {
+		t.Errorf("expected debug mode 'true', got %v", cfg.System.DebugMode)
+	}
+
+	if len(cfg.Software.PreloadKeys) != 2 || cfg.Software.PreloadKeys[0] != "git" || cfg.Software.PreloadKeys[1] != "vim" {
+		t.Errorf("expected preload keys ['git', 'vim'], got %v", cfg.Software.PreloadKeys)
+	}
+
+	if cfg.ConfigPath != configPath {
+		t.Errorf("expected config path %s, got %s", configPath, cfg.ConfigPath)
+	}
+}
+
+func TestLoadError(t *testing.T) {
+	// Test with non-existent file
+	_, err := Load("non-existent-file.yml")
+	if err == nil {
+		t.Fatal("expected error loading non-existent file, got nil")
+	}
+
+	// Test with invalid YAML
+	tempFile, err := os.CreateTemp("", "invalid-config-*.yml")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer os.Remove(tempFile.Name())
+
+	_, err = tempFile.WriteString("invalid: yaml: :")
+	if err != nil {
+		t.Fatalf("failed to write to temp file: %v", err)
+	}
+	tempFile.Close()
+
+	_, err = Load(tempFile.Name())
+	if err == nil {
+		t.Fatal("expected error loading invalid YAML, got nil")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	// Test valid config
+	cfg := DefaultConfig()
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected no validation error for default config, got %v", err)
+	}
+
+	// Test invalid theme
+	cfg.UI.Theme = "invalid"
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for invalid theme, got nil")
+	}
+
+	// Reset and test invalid detail height
+	cfg = DefaultConfig()
+	cfg.UI.DetailHeight = 0
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for invalid detail height, got nil")
+	}
+
+	// Reset and test invalid list height
+	cfg = DefaultConfig()
+	cfg.UI.ListHeight = -1
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for invalid list height, got nil")
+	}
+
+	// Reset and test empty manifest path
+	cfg = DefaultConfig()
+	cfg.Software.ManifestPath = ""
+	if err := cfg.Validate(); err == nil {
+		t.Error("expected validation error for empty manifest path, got nil")
+	}
+}
+
+func TestSave(t *testing.T) {
+	// Create a temporary directory for saving
+	tempDir, err := os.MkdirTemp("", "a-la-carte-save-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	savePath := filepath.Join(tempDir, "saved-config.yml")
+
+	// Create a config to save
+	cfg := DefaultConfig()
+	cfg.UI.Theme = "light"
+	cfg.Software.PreloadKeys = []string{"test1", "test2"}
+
+	// Save the config
+	err = cfg.Save(savePath)
+	if err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+
+	// Load the saved config
+	loadedCfg, err := Load(savePath)
+	if err != nil {
+		t.Fatalf("failed to load saved config: %v", err)
+	}
+
+	// Verify the saved values
+	if loadedCfg.UI.Theme != "light" {
+		t.Errorf("expected theme 'light', got %s", loadedCfg.UI.Theme)
+	}
+
+	if len(loadedCfg.Software.PreloadKeys) != 2 ||
+		loadedCfg.Software.PreloadKeys[0] != "test1" ||
+		loadedCfg.Software.PreloadKeys[1] != "test2" {
+		t.Errorf("expected preload keys ['test1', 'test2'], got %v", loadedCfg.Software.PreloadKeys)
+	}
+}

--- a/internal/config/format.go
+++ b/internal/config/format.go
@@ -1,0 +1,62 @@
+// Package config provides configuration management for the a-la-carte application.
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// OutputFormat defines the supported output formats for the application
+type OutputFormat string
+
+const (
+	// OutputFormatText represents plain text output format
+	OutputFormatText OutputFormat = "text"
+
+	// OutputFormatJSON represents JSON output format
+	OutputFormatJSON OutputFormat = "json"
+)
+
+// IsValidOutputFormat checks if the given format string is a valid output format
+func IsValidOutputFormat(format string) bool {
+	switch OutputFormat(format) {
+	case OutputFormatText, OutputFormatJSON:
+		return true
+	default:
+		return false
+	}
+}
+
+// FormatOutput formats data according to the specified output format
+func FormatOutput(data interface{}, format OutputFormat) (string, error) {
+	switch format {
+	case OutputFormatText:
+		return formatAsText(data)
+	case OutputFormatJSON:
+		return formatAsJSON(data)
+	default:
+		return "", fmt.Errorf("unsupported output format: %s", format)
+	}
+}
+
+// Helper functions for formatting output
+func formatAsText(data interface{}) (string, error) {
+	// Simple text formatting depends on the data type
+	switch v := data.(type) {
+	case string:
+		return v, nil
+	case []string:
+		return strings.Join(v, "\n"), nil
+	default:
+		return fmt.Sprintf("%v", data), nil
+	}
+}
+
+func formatAsJSON(data interface{}) (string, error) {
+	jsonBytes, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("error marshaling to JSON: %w", err)
+	}
+	return string(jsonBytes), nil
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ValidateManifestPath checks if the manifest path exists and is readable
+func (c *Config) ValidateManifestPath() error {
+	// If the manifest path is relative, prepend the config directory
+	manifestPath := c.Software.ManifestPath
+	if !filepath.IsAbs(manifestPath) && c.ConfigPath != "" {
+		configDir := filepath.Dir(c.ConfigPath)
+		manifestPath = filepath.Join(configDir, manifestPath)
+	}
+
+	// Check if the manifest file exists and is readable
+	info, err := os.Stat(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("manifest file not found: %s", manifestPath)
+		}
+		return fmt.Errorf("error accessing manifest file: %w", err)
+	}
+
+	if info.IsDir() {
+		return fmt.Errorf("manifest path is a directory, not a file: %s", manifestPath)
+	}
+
+	// Try to open the file to check if it's readable
+	f, err := os.Open(manifestPath)
+	if err != nil {
+		return fmt.Errorf("error opening manifest file: %w", err)
+	}
+	f.Close()
+
+	return nil
+}
+
+// ResolveManifestPath returns the absolute path to the manifest file
+func (c *Config) ResolveManifestPath() string {
+	manifestPath := c.Software.ManifestPath
+
+	// If it's already absolute, return it
+	if filepath.IsAbs(manifestPath) {
+		return manifestPath
+	}
+
+	// If we have a config file path, make the manifest path relative to it
+	if c.ConfigPath != "" {
+		configDir := filepath.Dir(c.ConfigPath)
+		return filepath.Join(configDir, manifestPath)
+	}
+
+	// Otherwise, use the current working directory
+	cwd, err := os.Getwd()
+	if err != nil {
+		// Fallback to just the relative path if we can't get the working directory
+		return manifestPath
+	}
+
+	return filepath.Join(cwd, manifestPath)
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -33,7 +33,12 @@ func (c *Config) ValidateManifestPath() error {
 	if err != nil {
 		return fmt.Errorf("error opening manifest file: %w", err)
 	}
-	f.Close()
+	defer func() {
+		if closeErr := f.Close(); closeErr != nil {
+			// If we already have an error, don't overwrite it
+			fmt.Fprintf(os.Stderr, "error closing config file: %v\n", closeErr)
+		}
+	}()
 
 	return nil
 }

--- a/internal/flags/README.md
+++ b/internal/flags/README.md
@@ -1,0 +1,79 @@
+# Flags Package
+
+This package provides command line flag handling for the a-la-carte application.
+
+## Overview
+
+The `flags` package manages command-line options, parses arguments, and provides validation for the application's command-line interface.
+
+## Command Line Options
+
+The package defines the following command-line options:
+
+| Argument          | Short | Description                                        | Default |
+| ----------------- | ----- | -------------------------------------------------- | ------- |
+| `--config FILE`   | `-c`  | Path to configuration file                         | ""      |
+| `--manifest FILE` | `-m`  | Path to software manifest file                     | ""      |
+| `--debug`         | `-d`  | Enable debug mode                                  | false   |
+| `--version`       | `-v`  | Show version and exit                              | false   |
+| `--help`          | `-h`  | Show help message                                  | false   |
+| `--output FORMAT` | `-o`  | Output format (text, json) for non-interactive use | "text"  |
+| `--quiet`         | `-q`  | Suppress non-essential output                      | false   |
+| `--no-emojis`     | `-E`  | Disable emojis in the UI                           | false   |
+
+## Main Functions
+
+- `Parse()`: Parses command line flags and returns the options
+- `ValidateOptions(opts *Options)`: Validates the command line options
+- `Usage()`: Prints detailed usage information
+
+## Output Format Validation
+
+The package validates output format options:
+
+- Currently supported: "text" and "json"
+- Returns an error for invalid formats
+
+## Example Usage
+
+```go
+// Parse command-line flags
+opts := flags.Parse()
+
+// Validate command-line options
+if err := flags.ValidateOptions(opts); err != nil {
+    fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+    flags.Usage()
+    os.Exit(1)
+}
+
+// Handle help flag
+if opts.Help {
+    flags.Usage()
+    return
+}
+
+// Use the parsed options
+if opts.Debug {
+    // Enable debug mode
+}
+
+if opts.Version {
+    // Show version information
+}
+```
+
+## Integration with Configuration
+
+The flags package is designed to work seamlessly with the `config` package:
+
+1. Command-line flags are parsed first
+2. The `--config` flag (if provided) points to a custom config file
+3. Other flags can override settings from the config file
+
+## Potential Improvements
+
+- Support for environment variable overrides for individual settings
+- Additional output formats beyond text and JSON
+- Command completion for shells like bash/zsh
+- Interactive help with examples

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -1,0 +1,101 @@
+// Package flags provides command line flag handling for the a-la-carte application
+package flags
+
+import (
+	"flag"
+	"fmt"
+)
+
+// Options defines the command line options for the application
+type Options struct {
+	// ConfigPath is the path to the configuration file
+	ConfigPath string
+
+	// ManifestPath is the path to the software manifest file
+	ManifestPath string
+
+	// Debug enables debug mode
+	Debug bool
+
+	// Version shows the version and exits
+	Version bool
+
+	// Help shows the help message and exits
+	Help bool
+
+	// OutputFormat defines the output format for non-interactive commands
+	OutputFormat string
+
+	// Quiet suppresses non-essential output
+	Quiet bool
+
+	// NoEmojis disables emoji display in the UI
+	NoEmojis bool
+}
+
+// Parse parses command line flags and returns the options
+func Parse() *Options {
+	opts := &Options{}
+
+	// Define long-form flags
+	flag.StringVar(&opts.ConfigPath, "config", "", "Path to configuration file")
+	flag.StringVar(&opts.ManifestPath, "manifest", "", "Path to software manifest file")
+	flag.BoolVar(&opts.Debug, "debug", false, "Enable debug mode")
+	flag.BoolVar(&opts.Version, "version", false, "Show version and exit")
+	flag.BoolVar(&opts.Help, "help", false, "Show help message")
+	flag.StringVar(&opts.OutputFormat, "output", "text", "Output format (text, json)")
+	flag.BoolVar(&opts.Quiet, "quiet", false, "Suppress non-essential output")
+	flag.BoolVar(&opts.NoEmojis, "no-emojis", false, "Disable emojis in the UI")
+
+	// Define short aliases
+	flag.StringVar(&opts.ConfigPath, "c", "", "Path to configuration file (shorthand)")
+	flag.StringVar(&opts.ManifestPath, "m", "", "Path to software manifest file (shorthand)")
+	flag.BoolVar(&opts.Debug, "d", false, "Enable debug mode (shorthand)")
+	flag.BoolVar(&opts.Version, "v", false, "Show version and exit (shorthand)")
+	flag.BoolVar(&opts.Help, "h", false, "Show help message (shorthand)")
+	flag.StringVar(&opts.OutputFormat, "o", "text", "Output format (shorthand)")
+	flag.BoolVar(&opts.Quiet, "q", false, "Suppress non-essential output (shorthand)")
+	flag.BoolVar(&opts.NoEmojis, "E", false, "Disable emojis in the UI (shorthand)")
+
+	flag.Parse()
+	return opts
+}
+
+// Usage prints usage information
+func Usage() {
+	fmt.Println("Usage: chezmoi-a-la-carte [options]")
+	fmt.Println("\nA terminal user interface (TUI) for browsing and managing software manifests.")
+	fmt.Println("\nOptions:")
+	flag.PrintDefaults()
+
+	fmt.Println("\nConfiguration:")
+	fmt.Println("  Configuration is loaded from the following sources in order of precedence:")
+	fmt.Println("  1. Environment variable: A_LA_CARTE_CONFIG=/path/to/config.yml")
+	fmt.Println("  2. Command line flag: --config /path/to/config.yml")
+	fmt.Println("  3. Default location: $HOME/.config/a-la-carte/a-la-carte.yml")
+	fmt.Println("  4. Built-in defaults")
+
+	fmt.Println("\nKeyboard Controls:")
+	fmt.Println("  ↑/↓/j/k:  Move selection")
+	fmt.Println("  /:        Start search")
+	fmt.Println("  q:        Quit")
+	fmt.Println("  Enter:    Show details")
+	fmt.Println("  esc:      Cancel search")
+	fmt.Println("  TAB:      Toggle focus between list and details")
+
+	fmt.Println("\nExamples:")
+	fmt.Println("  # Run with a custom config file")
+	fmt.Println("  chezmoi-a-la-carte --config /path/to/config.yml")
+	fmt.Println()
+	fmt.Println("  # Run with a specific manifest file")
+	fmt.Println("  chezmoi-a-la-carte --manifest /path/to/software.yml")
+	fmt.Println()
+	fmt.Println("  # Run in debug mode")
+	fmt.Println("  chezmoi-a-la-carte --debug")
+	fmt.Println()
+	fmt.Println("  # Disable emoji display in the UI")
+	fmt.Println("  chezmoi-a-la-carte --no-emojis")
+	fmt.Println()
+	fmt.Println("  # Output in JSON format (for scripting)")
+	fmt.Println("  chezmoi-a-la-carte --output json --quiet")
+}

--- a/internal/flags/validate.go
+++ b/internal/flags/validate.go
@@ -1,0 +1,26 @@
+package flags
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ValidateOptions validates the command line options and returns an error if invalid
+func ValidateOptions(opts *Options) error {
+	// Validate output format
+	if !isValidOutputFormat(opts.OutputFormat) {
+		return fmt.Errorf("invalid output format: %s (must be 'text' or 'json')", opts.OutputFormat)
+	}
+
+	return nil
+}
+
+// isValidOutputFormat checks if the given format is valid
+func isValidOutputFormat(format string) bool {
+	validFormats := map[string]bool{
+		"text": true,
+		"json": true,
+	}
+
+	return validFormats[strings.ToLower(format)]
+}


### PR DESCRIPTION
This pull request introduces several notable updates across documentation, configuration files, codebase, and dependencies. The changes enhance commit message generation, improve configuration management, refine workspace settings, and add new fields to the manifest structure. Below is a breakdown of the most important changes grouped by theme.

### Commit Message Standardization
* Added `.github/commit-message.md` to define a standardized format for git commit messages, compatible with Conventional Commits v1.0.0 and release-please integration. This includes detailed instructions, examples, and output rules for generating commit messages.

### Configuration Enhancements
* Updated `docs/configuration-system.md` and `docs/configuration.md` to provide comprehensive documentation on configuration loading precedence, file formats, and command-line arguments for the `a-la-carte` application. This includes YAML examples and environment variable usage. [[1]](diffhunk://#diff-2db91bda3b44fa41186d106cb0d69b77acdb04be037a1649944afc4b442285bdR1-R106) [[2]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R1-R146)
* Added new fields (`Deps`, `App`, `Script`, `Lazy`) to the `SoftwareEntry` struct in `internal/app/manifest.go` for enhanced provisioning and dependency management.

### Workspace and Linter Adjustments
* Renamed the workspace folder name in `a-la-carte.code-workspace` for better readability and updated workspace settings to include Copilot commit message generation instructions. Removed redundant Go lint tool settings. [[1]](diffhunk://#diff-343df091f409f046f6814762c96d25fa49199fa245b132b191e8c18f7ce30474L5-R5) [[2]](diffhunk://#diff-343df091f409f046f6814762c96d25fa49199fa245b132b191e8c18f7ce30474L35-R46) [[3]](diffhunk://#diff-343df091f409f046f6814762c96d25fa49199fa245b132b191e8c18f7ce30474L78-L83)
* Disabled shadowing checks in `govet` linter settings in `.golangci.yml` to simplify linting configurations.

### Dependency Updates
* Added new dependencies (`github.com/76creates/stickers` and `github.com/charmbracelet/bubbles`) in `go.mod` to extend functionality for UI and clipboard management. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R8-R9) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R18)

### Documentation Improvements
* Created `internal/config/README.md` to document the `config` package, detailing its structure, precedence, validation, and usage examples. This serves as a guide for developers working with configuration management.